### PR TITLE
#164771609 Share Github user profile from detail view

### DIFF
--- a/app/src/main/java/com/example/javadevnai/view/DevDetails.java
+++ b/app/src/main/java/com/example/javadevnai/view/DevDetails.java
@@ -1,6 +1,7 @@
 package com.example.javadevnai.view;
 
 import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -30,6 +31,9 @@ public class DevDetails extends AppCompatActivity implements JavaGithubUserView 
     TextView repo;
     TextView organisation;
 
+    String githubUsername;
+    String githubURL;
+
     GithubPresenter presenter;
 
     @Override
@@ -51,9 +55,8 @@ public class DevDetails extends AppCompatActivity implements JavaGithubUserView 
         organisation = this.findViewById(R.id.organisation);
 
         presenter = new GithubPresenter(this);
-        String username = getIntent().getExtras().getString("username");
-        presenter.getJavaUser(username);
-        Log.d("Name", username);
+        githubUsername = getIntent().getExtras().getString("username");
+        presenter.getJavaUser(githubUsername);
     }
 
     @Override
@@ -66,7 +69,15 @@ public class DevDetails extends AppCompatActivity implements JavaGithubUserView 
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.share:
-                Toast.makeText(context, "You clicked the share button", Toast.LENGTH_SHORT).show();
+                Intent sharingIntent = new Intent(android.content.Intent.ACTION_SEND);
+                sharingIntent.setType("text/plain");
+                String shareBodyText = String.format("Check out this awesome developer @%s, %s.", githubUsername, githubURL);
+                String shareSubject = "Java Github Developer Nairobi";
+                sharingIntent.putExtra(android.content.Intent.EXTRA_SUBJECT, shareSubject);
+                sharingIntent.putExtra(android.content.Intent.EXTRA_TEXT, shareBodyText);
+
+                startActivity(Intent.createChooser(sharingIntent, "Share via"));
+                Toast.makeText(context, shareBodyText, Toast.LENGTH_SHORT).show();
                 break;
         }
         return super.onOptionsItemSelected(item);
@@ -82,7 +93,9 @@ public class DevDetails extends AppCompatActivity implements JavaGithubUserView 
         followers.setText(javaGithubNaiUser.getFollowers()+"");
         followings.setText(javaGithubNaiUser.getFollowing()+"");
         repo.setText(javaGithubNaiUser.getRepo()+"");
-        githubUrl.setText(javaGithubNaiUser.getHtmlUrl());
+
+        githubURL = javaGithubNaiUser.getHtmlUrl();
+        githubUrl.setText(githubURL);
 
         String info = javaGithubNaiUser.getBio();
         String company = javaGithubNaiUser.getCompany();


### PR DESCRIPTION
### What does this PR do?
It adds sharing functionality for GitHub profiles in detail view.

### Description of Task to be completed?
* Create intent for sharing when the share button is clicked.
* Add GitHub name and profile link to the body of the share intent.

### How should this be manually tested?
* Clone this Repo
* Checkout into this branch ft-share-github-user-profile-164771609
* Run the App in the emulator.
* Click on any developers profile picture
* Click on the share button when the profile of the developer opens
* Click the application you want to share via
* You should see a text in the body similar to the template below
"Check out this awesome developer @<github username>, <github profile url>."

### What are the relevant pivotal tracker stories?
[#164771609](https://www.pivotaltracker.com/story/show/164771609)

### Screenshots
<img width="301" alt="Screen Shot 2019-04-08 at 12 27 52 PM" src="https://user-images.githubusercontent.com/32283153/55720884-cba7a080-59f9-11e9-9c82-8f211efb8660.png">