### PR TITLE
#164771600 Handle Configuration Changes

### DIFF
--- a/app/src/main/java/com/example/javadevnai/model/JavaGithubNai.java
+++ b/app/src/main/java/com/example/javadevnai/model/JavaGithubNai.java
@@ -1,8 +1,11 @@
 package com.example.javadevnai.model;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import com.google.gson.annotations.SerializedName;
 
-public class JavaGithubNai {
+public class JavaGithubNai implements Parcelable {
     @SerializedName("html_url")
     protected String htmlUrl;
     @SerializedName("avatar_url")
@@ -21,6 +24,30 @@ public class JavaGithubNai {
     protected String bio;
     @SerializedName("company")
     protected String company;
+
+    protected JavaGithubNai(Parcel in) {
+        htmlUrl = in.readString();
+        avatarUrl = in.readString();
+        name = in.readString();
+        username = in.readString();
+        followers = in.readInt();
+        following = in.readInt();
+        publicPepos = in.readInt();
+        bio = in.readString();
+        company = in.readString();
+    }
+
+    public static final Creator<JavaGithubNai> CREATOR = new Creator<JavaGithubNai>() {
+        @Override
+        public JavaGithubNai createFromParcel(Parcel in) {
+            return new JavaGithubNai(in);
+        }
+
+        @Override
+        public JavaGithubNai[] newArray(int size) {
+            return new JavaGithubNai[size];
+        }
+    };
 
     public String getHtmlUrl() {
         return this.htmlUrl;
@@ -56,5 +83,23 @@ public class JavaGithubNai {
 
     public String getCompany() {
         return this.company;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(htmlUrl);
+        dest.writeString(avatarUrl);
+        dest.writeString(name);
+        dest.writeString(username);
+        dest.writeInt(followers);
+        dest.writeInt(following);
+        dest.writeInt(publicPepos);
+        dest.writeString(bio);
+        dest.writeString(company);
     }
 }

--- a/app/src/main/java/com/example/javadevnai/service/GithubAPI.java
+++ b/app/src/main/java/com/example/javadevnai/service/GithubAPI.java
@@ -8,9 +8,9 @@ import retrofit2.http.GET;
 import retrofit2.http.Path;
 
 public interface GithubAPI {
-    @GET("/search/users?q=location:nairobi+language:java&page=1&per_page=16")
+    @GET("/search/users?q=location:nairobi+language:java&page=1&per_page=18")
     Call<JavaGithubResponse> getAllJavaUsers();
 
-    @GET("/users/{username}?access_token=93c26b99324d2f3dafe7e1bacd5ff02f177dfae9")
+    @GET("/users/{username}?access_token=d5814d4993b0d7edfb1ecb19dcfc72c1c45555f5")
     Call<JavaGithubNai> getSpecificJavaUser(@Path("username") String username);
 }

--- a/app/src/main/java/com/example/javadevnai/view/DevDetails.java
+++ b/app/src/main/java/com/example/javadevnai/view/DevDetails.java
@@ -1,7 +1,7 @@
 package com.example.javadevnai.view;
 
-import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.constraint.ConstraintLayout;
 import android.support.v7.app.AppCompatActivity;
@@ -16,12 +16,10 @@ import android.widget.TextView;
 import com.example.javadevnai.R;
 import com.example.javadevnai.model.JavaGithubNai;
 import com.example.javadevnai.presenter.GithubPresenter;
+import com.google.gson.Gson;
 import com.squareup.picasso.Picasso;
 
 public class DevDetails extends AppCompatActivity implements JavaGithubUserView {
-
-    Context context = this;
-
     ImageView avatar;
     TextView username;
     TextView fullname;
@@ -41,6 +39,8 @@ public class DevDetails extends AppCompatActivity implements JavaGithubUserView 
 
     ConstraintLayout loader;
     ConstraintLayout dev_detail;
+
+    JavaGithubNai mGithubUser;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -95,6 +95,8 @@ public class DevDetails extends AppCompatActivity implements JavaGithubUserView 
 
     @Override
     public void displayJavaUser(JavaGithubNai javaGithubNaiUser) {
+        mGithubUser = javaGithubNaiUser;
+
         Picasso.get().load(javaGithubNaiUser.getAvatarUrl()).into(avatar);
         username.setText(javaGithubNaiUser.getUsername());
 
@@ -125,5 +127,27 @@ public class DevDetails extends AppCompatActivity implements JavaGithubUserView 
 
         loader.setVisibility(View.GONE);
         dev_detail.setVisibility(View.VISIBLE);
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        String serializedGithubUser = new Gson().toJson(mGithubUser);
+        SharedPreferences githubUser = getSharedPreferences("JavaGithubUser", MODE_PRIVATE);
+        SharedPreferences.Editor editor = githubUser.edit();
+        editor.putString("javaGithubUser", serializedGithubUser);
+        editor.apply();
+
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        SharedPreferences githubUser = getSharedPreferences("JavaGithubUser", MODE_PRIVATE);
+        String serializedGithubUser = githubUser.getString("javaGithubUser", null);
+        JavaGithubNai mGithubUser = new Gson().fromJson(serializedGithubUser, JavaGithubNai.class);
+        if (mGithubUser != null) {
+            displayJavaUser(mGithubUser);
+        }
     }
 }

--- a/app/src/main/res/layout/content_dev_details.xml
+++ b/app/src/main/res/layout/content_dev_details.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
 <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     app:layout_behavior="@string/appbar_scrolling_view_behavior"
     android:id="@+id/dev_detail"
     tools:context=".view.DevDetails"
@@ -22,7 +27,7 @@
             android:layout_width="193dp"
             android:layout_height="193dp"
             android:layout_marginStart="8dp"
-            android:layout_marginTop="10dp"
+            android:layout_marginTop="70dp"
             android:layout_marginEnd="8dp"
             android:src="@drawable/man"
             app:civ_border_color="#C4C4C4"
@@ -88,7 +93,7 @@
 
     <android.support.constraint.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="383dp"
+        android:layout_height="wrap_content"
         android:padding="20sp"
         app:layout_constraintTop_toBottomOf="@+id/constraintLayout">
 
@@ -228,3 +233,4 @@
     </android.support.constraint.ConstraintLayout>
 
 </android.support.constraint.ConstraintLayout>
+</ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,22 +1,10 @@
 <resources>
     <string name="app_name">Java Dev Nai</string>
     <string name="dev_name">@maxfurry</string>
-    <string-array name="dev_list">
-        <item>@maxfurry</item>
-        <item>@luckzman</item>
-        <item>@etlneg</item>
-        <item>@ibro</item>
-        <item>@peerless</item>
-        <item>@maxfurry</item>
-        <item>@luckzman</item>
-        <item>@etlneg</item>
-        <item>@ibro</item>
-        <item>@peerless</item>
-        <item>@macodinas</item>
-    </string-array>
     <string name="title_activity_dev_detail">DevDetailActivity</string>
     <string name="title_activity_dev_details">Profile</string>
     <string name="star_andela">\u2605 Andela</string>
     <string name="loading">Loading...</string>
-    <integer name="grid_count">2</integer>
+    <integer name="grid_count_portrait">2</integer>
+    <integer name="grid_count_landscape">3</integer>
 </resources>


### PR DESCRIPTION
### What does this PR do?
It configures the device for landscape orientation
It prevents the app from reloading data when the device configuration changes.

### Description of Task to be completed?
* Make grid count 3 when orientations change to three(3)
* Make detail view scrollable when in landscape mode so that all content can be viewed
* Override the onPause and onResume functions on main activity and detail activity

### How should this be manually tested?
* Clone this repo
* Checkout to branch ft-handle-configuration-changes-164771600
* Run emulator
* Change orientation from portrait to landscape and vice-versa
* App should not reload

### What are the relevant pivotal tracker stories?
[#164771600](https://www.pivotaltracker.com/story/show/164771600)

### Screenshoot
![handle config change](https://user-images.githubusercontent.com/32283153/55947254-04d45080-5c46-11e9-9950-d0b5976c2422.gif)